### PR TITLE
Add support for cargo workspace `members` array.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-renamepkg"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["ProgramSalamander <464243149@qq.com>"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cargo-renamepkg
-This is a simple utility to help you rename a cargo package when you may create a package with an unexpected name or just want to change its name.
+This is a simple utility to help you rename a cargo package when you may create
+a package with an unexpected name or just want to change its name. If inside a cargo
+workspace the package name is also automatically updated in the members array. (Since v1.2)
 
 ## Use Case
 Suppose that you wanted to do this:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,13 @@
 //! ```
 extern crate toml_edit;
 use clap::ArgMatches;
-use std::error::Error;
 use std::fs;
 use std::fs::OpenOptions;
-use std::io::prelude::*;
 use std::io;
+use std::io::prelude::*;
 use std::path::PathBuf;
+use std::{env::current_dir, error::Error};
+use toml::Value;
 use toml_edit::{value, Document};
 
 pub fn run(config: ArgMatches) -> Result<(), Box<dyn Error>> {
@@ -63,11 +64,48 @@ pub fn run(config: ArgMatches) -> Result<(), Box<dyn Error>> {
 
     // update Cargo.toml
     doc["package"]["name"] = value(new_name);
-    // fs::write(toml_file.get_path(), );
-    fs::write(&target_path.join("Cargo.toml"), doc.to_string().as_bytes())?;
 
+    fs::write(&target_path.join("Cargo.toml"), doc.to_string().as_bytes())?;
     let new_path = target_path.parent().unwrap().join(&new_name);
     fs::rename(&target_path, &new_path)?;
+
+    // find the Cargo.toml for the workspace
+    let workspace_toml_path = current_dir()
+        .expect("should have current dir")
+        .join("Cargo.toml");
+    if workspace_toml_path.is_file() {
+        let mut toml_workspace_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .append(false)
+            .open(workspace_toml_path)?;
+        let mut toml_contents_workspace = String::new();
+        toml_workspace_file.read_to_string(&mut toml_contents_workspace)?;
+
+        let mut doc_workspace: Value = toml::from_str(toml_contents_workspace.as_str())?;
+        if let Some(members_mut) = doc_workspace
+            .get_mut("workspace")
+            .and_then(|w| w.get_mut("members"))
+            .and_then(Value::as_array_mut)
+        {
+            let target_name = target_path
+                .file_name()
+                .expect("Expected the target path to have valid file name. This is a YOU problem.")
+                .to_string_lossy();
+            if let Some(index) = members_mut
+                .iter()
+                .position(|member| *member == Value::String(target_name.to_string()))
+            {
+                members_mut[index] = Value::String(new_name.to_string());
+            }
+        }
+        fs::write(
+            current_dir()
+                .expect("should have current dir")
+                .join("Cargo.toml"),
+            doc_workspace.to_string().as_bytes(),
+        )?;
+    }
 
     println!("completed");
     Ok(())


### PR DESCRIPTION
Updates the name in the members array if inside a cargo workspace.